### PR TITLE
Minor fixes 

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -27,13 +27,13 @@ KeepassEntry="keepass2://test.kdbx/Root/gocfl/test"
 KeepassKey="%%GOCFL_KEEPASS_KEY%%"
 
 [test]
-fixturepath = "./fixtures/1.1/bad-objects"
+fixturepath = "../fixtures/1.1/bad-objects"
 
 [init]
 # --ocfl-version
 OCFLVersion="1.1"
 # --default-storageroot-extensions
-#StorageRootExtensions="./data/defaultextensions/storageroot"
+#StorageRootExtensions="../data/defaultextensions/storageroot"
 # --digest
 Digest="sha512"
 
@@ -45,7 +45,7 @@ Digest="sha512"
 # --fixity
 Fixity=["sha256", "sha1", "md5"]
 # --default-object-extensions
-#ObjectExtensions="./data/fullextensions/object"
+#ObjectExtensions="../data/fullextensions/object"
 deduplicate = false
 nocompress = true
 

--- a/pkg/ocfl/inventory/inventorytest/common_test.go
+++ b/pkg/ocfl/inventory/inventorytest/common_test.go
@@ -19,7 +19,7 @@ import (
 
 func getFactory(ctx context.Context, ver version.OCFLVersion) factory.Factory {
 	var logger = zerolog.New(zerolog.NewConsoleWriter())
-	return factoryimpl.NewFactory(ver, nil, ocfllogger.NewOCFLLogger(ctx, &logger, nil, ver))
+	return factoryimpl.NewFactory(ver, nil, ocfllogger.NewOCFLLogger(ctx, &logger, nil, ver, nil))
 }
 
 func genericExampleState(ver version.OCFLVersion, cnt int, t *testing.T) inventory.State {

--- a/pkg/ocfl/object/objectimpl/versionWriter.go
+++ b/pkg/ocfl/object/objectimpl/versionWriter.go
@@ -192,7 +192,7 @@ func (versionWriter *versionWriter) storeExtensions() error {
 
 func (versionWriter *versionWriter) Close() error {
 	inv := versionWriter.GetInventory()
-	versionWriter.logger.Info().Msgf(fmt.Sprintf("Closing Version %s of object '%s'", versionWriter.ver.String(), inv.GetID()))
+	versionWriter.logger.Info().Msgf("Closing Version %s of object '%s'", versionWriter.ver.String(), inv.GetID())
 	if !(inv.IsWriteable()) {
 		return nil
 	}


### PR DESCRIPTION
* Tests failing because of an incorrect Msgf in Go 1.24
* Default.toml relative paths `./` don't work in Linux and require `../`