### PR TITLE
AddFile test

### DIFF
--- a/justfile
+++ b/justfile
@@ -14,6 +14,10 @@ imports:
 test:
   go test ./...
 
+# run tests with coverage (requires version alignment)
+test-cov:
+  go test -coverprofile= ./...
+
 # clear test cache
 rm-test-cache:
   go clean -testcache

--- a/pkg/ocfl/inventory/inventoryimpl/inventory_impl_test.go
+++ b/pkg/ocfl/inventory/inventoryimpl/inventory_impl_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"emperror.dev/errors"
 	"github.com/je4/utils/v2/pkg/checksum"
 	"github.com/je4/utils/v2/pkg/zLogger"
 	"github.com/ocfl-archive/gocfl/v3/pkg/ocfl/inventory"
@@ -35,7 +36,8 @@ type inventoryTest struct {
 	expectedFilesFlat []string
 	// Brittle and prone to break with i18n but might be useful in
 	// these early tests to discuss.
-	manifestText string
+	manifestText  string
+	expectedError error
 }
 
 // Basic inventory that can be partially loaded into memory. Ideally
@@ -215,5 +217,144 @@ func addFileTest(t *testing.T, test inventoryTest) {
 func TestAddFile(t *testing.T) {
 	for _, test := range inventoryTests {
 		addFileTest(t, test)
+	}
+}
+
+var inventoryEx2 = `
+{
+   "id": "ex:1",
+   "type": "https://ocfl.io/1.1/spec/#inventory",
+   "digestAlgorithm": "sha512",
+   "head": "v1",
+   "manifest": {
+      "1a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": [
+         "v1/content/test.file1"
+      ],
+      "2a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": [
+         "v1/content/test.file2"
+      ]
+   },
+   "fixity": {}
+}
+`
+
+var inventoryEx3 = `
+{
+   "id": "ex:1",
+   "type": "https://ocfl.io/1.1/spec/#inventory",
+   "digestAlgorithm": "md5",
+   "head": "v1",
+   "manifest": {
+      "1a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": [
+         "v1/content/test.file1"
+      ],
+      "2a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": [
+         "v1/content/test.file2"
+      ]
+   },
+   "fixity": {}
+}
+`
+
+const DigestFake checksum.DigestAlgorithm = "UnknownDigest"
+
+var inventoryTestsChecksumError = []inventoryTest{
+	// Uses an unknown checksum type. NB. also an invalid checkum string.
+	{
+		testData: inventoryEx2,
+		fileData: fileData{
+			stateFilename:    []string{""},
+			manifestFilename: "",
+			checksumData: map[checksum.DigestAlgorithm]string{
+				DigestFake: "checksum123",
+			},
+		},
+		modified:      false,
+		expectedError: errors.New("no digest for 'sha512' in checksums"),
+	},
+	// Tries to add SHA512 checksum to MD5 manifest. NB. also an
+	// invalid checkum string.
+	{
+		testData: inventoryEx3,
+		fileData: fileData{
+			stateFilename:    []string{""},
+			manifestFilename: "",
+			checksumData: map[checksum.DigestAlgorithm]string{
+				checksum.DigestSHA512: "checksumSHA512",
+			},
+		},
+		modified:      false,
+		expectedError: errors.New("no digest for 'md5' in checksums"),
+	},
+}
+
+func addFileTestChecksumError(t *testing.T, test inventoryTest) {
+	ctx := context.TODO()
+	zerologger := zerolog.New(os.Stderr).With().Str("timestamp", time.Now().String()).Logger()
+	var zlogger zLogger.ZLogger = &zerologger
+	var logger = ocfllogger.NewOCFLLogger(ctx, zlogger, nil, version.Default, nil)
+
+	// Initial state.
+	testState := &stateBase{
+		State: map[string][]string{
+			"1a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": []string{"test.file1"},
+			"2a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": []string{"test.file2"},
+		},
+	}
+
+	testVersion := &versionBase{
+		Created: inventory.NewOCFLTime(time.Now()),
+		Message: inventory.NewOCFLString(""),
+		State:   testState,
+	}
+
+	testVersions := &versionsBase{
+		// It is unclear why it isn't possible to load the JSON version
+		// into memory so we do it manually.
+		versions:    map[int]inventory.Version{0: testVersion},
+		versionInts: map[string]int{"v1": 0},
+	}
+
+	testInventory := InventoryBase{
+		Manifest: &ManifestBase{
+			manifest: map[string][]string{},
+		},
+		Versions: testVersions,
+		Fixity: &FixityBase{
+			fixity: map[checksum.DigestAlgorithm]map[string][]string{},
+		},
+	}
+
+	err := json.Unmarshal([]byte(test.testData), &testInventory)
+	if err != nil {
+		t.Fatal("error unmarshalling JSON from test:", err)
+	}
+
+	testInventory.logger = logger
+	err = testInventory.AddFile(
+		test.fileData.stateFilename,
+		test.fileData.manifestFilename,
+		test.fileData.checksumData,
+	)
+	if err == nil {
+		t.Fatal("error is nil, expected a checksum validation error")
+	}
+
+	if testInventory.modified != test.modified {
+		t.Fatalf(
+			"inventory modified incorrectly: '%t', expected: '%t'",
+			testInventory.modified,
+			test.modified,
+		)
+	}
+
+	if err.Error() != test.expectedError.Error() {
+		t.Fatalf("expectedd error '%s', got '%s'", err, test.expectedError)
+	}
+}
+
+func TestAddFileChecksumErrors(t *testing.T) {
+	for _, test := range inventoryTestsChecksumError {
+		addFileTestChecksumError(t, test)
 	}
 }

--- a/pkg/ocfl/inventory/inventoryimpl/inventory_impl_test.go
+++ b/pkg/ocfl/inventory/inventoryimpl/inventory_impl_test.go
@@ -394,6 +394,23 @@ var inventoryTestVersionErrors = []inventoryTest{
 			"cannot add for duplicate of '[test.file2]' [2a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea]: checksum for version  does not exist",
 		),
 	},
+	// Checksum for a new version does not exist.
+	{
+		testData: inventoryEx1,
+		fileData: fileData{
+			stateFilename:    []string{"test.file2"},
+			manifestFilename: "v1/content/test.file2",
+			checksumData: map[checksum.DigestAlgorithm]string{
+				checksum.DigestSHA512: "9a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea",
+			},
+		},
+		// TODO: This looks like an invalid condition as we get an error
+		// and it is marked as modified which it is.
+		modified: true,
+		expectedError: errors.New(
+			"cannot add for duplicate of '[test.file2]' [9a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea]: checksum for version  does not exist",
+		),
+	},
 }
 
 func addFileTestVersionErrors(t *testing.T, test inventoryTest) {

--- a/pkg/ocfl/inventory/inventoryimpl/inventory_impl_test.go
+++ b/pkg/ocfl/inventory/inventoryimpl/inventory_impl_test.go
@@ -1,3 +1,4 @@
+//nolint:all
 package inventoryimpl
 
 import (

--- a/pkg/ocfl/inventory/inventoryimpl/inventory_impl_test.go
+++ b/pkg/ocfl/inventory/inventoryimpl/inventory_impl_test.go
@@ -358,3 +358,119 @@ func TestAddFileChecksumErrors(t *testing.T) {
 		addFileTestChecksumError(t, test)
 	}
 }
+
+var inventoryEx4 = `
+{
+   "id": "ex:1",
+   "type": "https://ocfl.io/1.1/spec/#inventory",
+   "digestAlgorithm": "sha512",
+   "head": "v1",
+   "manifest": {
+      "1a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": [
+         "v1/content/test.file1"
+      ],
+      "2a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": [
+         "v1/content/test.file2"
+      ]
+   },
+   "fixity": {}
+}
+`
+
+var inventoryTestVersionErrors = []inventoryTest{
+	// Try adding a duplicate file but the version doesn't exist in
+	// the base inventory.
+	{
+		testData: inventoryEx1,
+		fileData: fileData{
+			stateFilename:    []string{"test.file2"},
+			manifestFilename: "v1/content/test.file2",
+			checksumData: map[checksum.DigestAlgorithm]string{
+				checksum.DigestSHA512: "2a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea",
+			},
+		},
+		modified: false,
+		expectedError: errors.New(
+			"cannot add for duplicate of '[test.file2]' [2a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea]: checksum for version  does not exist",
+		),
+	},
+}
+
+func addFileTestVersionErrors(t *testing.T, test inventoryTest) {
+	ctx := context.TODO()
+	zerologger := zerolog.New(os.Stderr).With().Str("timestamp", time.Now().String()).Logger()
+	var zlogger zLogger.ZLogger = &zerologger
+	var logger = ocfllogger.NewOCFLLogger(ctx, zlogger, nil, version.Default, nil)
+
+	// Initial state.
+	testState := &stateBase{
+		State: map[string][]string{
+			"1a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": []string{"test.file1"},
+			"2a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": []string{"test.file2"},
+		},
+	}
+
+	vers := &inventory.VersionNumber{}
+	vers.Init(99, "v1")
+
+	testVersion := &versionBase{
+		version: vers,
+		Created: inventory.NewOCFLTime(time.Now()),
+		Message: inventory.NewOCFLString(""),
+		State:   testState,
+	}
+
+	testVersions := &versionsBase{
+		// It is unclear why it isn't possible to load the JSON version
+		// into memory so we do it manually.
+		versions:    map[int]inventory.Version{0: testVersion},
+		versionInts: map[string]int{"v1": 0},
+	}
+
+	testInventory := InventoryBase{
+		Manifest: &ManifestBase{
+			manifest: map[string][]string{},
+		},
+		Versions: testVersions,
+		Fixity: &FixityBase{
+			fixity: map[checksum.DigestAlgorithm]map[string][]string{},
+		},
+	}
+
+	err := json.Unmarshal([]byte(test.testData), &testInventory)
+	if err != nil {
+		t.Fatal("error unmarshalling JSON from test:", err)
+	}
+
+	testInventory.logger = logger
+	err = testInventory.AddFile(
+		test.fileData.stateFilename,
+		test.fileData.manifestFilename,
+		test.fileData.checksumData,
+	)
+	if err == nil {
+		t.Errorf("error is nil but we expect an error")
+	}
+
+	if err.Error() != test.expectedError.Error() {
+		t.Errorf(
+			"error '%s' is not expected error '%s'",
+			err.Error(),
+			test.expectedError.Error(),
+		)
+	}
+
+	if testInventory.modified != test.modified {
+		t.Errorf(
+			"modified state incorrectly updated as '%t', expected: '%t'",
+			testInventory.modified,
+			test.modified,
+		)
+	}
+}
+
+func TestAddFileVersionErrors(t *testing.T) {
+	for _, test := range inventoryTestVersionErrors {
+		addFileTestVersionErrors(t, test)
+	}
+}

--- a/pkg/ocfl/inventory/inventoryimpl/inventory_impl_test.go
+++ b/pkg/ocfl/inventory/inventoryimpl/inventory_impl_test.go
@@ -1,0 +1,219 @@
+package inventoryimpl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/je4/utils/v2/pkg/checksum"
+	"github.com/je4/utils/v2/pkg/zLogger"
+	"github.com/ocfl-archive/gocfl/v3/pkg/ocfl/inventory"
+	"github.com/ocfl-archive/gocfl/v3/pkg/ocfl/version"
+	"github.com/ocfl-archive/gocfl/v3/pkg/ocfllogger"
+	"github.com/rs/zerolog"
+)
+
+type fileData struct {
+	stateFilename    []string
+	manifestFilename string
+	checksumData     map[checksum.DigestAlgorithm]string
+}
+
+type inventoryTest struct {
+	testData          string
+	fileData          fileData
+	modified          bool
+	getChecksum       string
+	expectedFiles     []string
+	expectedFilesFlat []string
+	// Brittle and prone to break with i18n but might be useful in
+	// these early tests to discuss.
+	manifestText string
+}
+
+// Basic inventory that can be partially loaded into memory. Ideally
+// we would do more with the version and fixity field but they're not
+// used that this point in the code.
+//
+// The field : "versions": {"v1": {
+// cannot be loaded into memory at this point but I could be
+// initializing a portion of the code incorrectly.
+//
+// Only Manifest is updated in this test.
+var inventoryEx1 = `
+{
+   "id": "ex:1",
+   "type": "https://ocfl.io/1.1/spec/#inventory",
+   "digestAlgorithm": "sha512",
+   "head": "v1",
+   "manifest": {
+      "1a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": [
+         "v1/content/test.file1"
+      ],
+      "2a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": [
+         "v1/content/test.file2"
+      ]
+   },
+   "fixity": {}
+}
+`
+
+var inventoryTests = []inventoryTest{
+	// Adds duplicate with different filename. 3 files, 2 unique.
+	{
+		testData: inventoryEx1,
+		fileData: fileData{
+			stateFilename:    []string{"add.file1"},
+			manifestFilename: "v1/content/add.file1",
+			checksumData: map[checksum.DigestAlgorithm]string{
+				checksum.DigestSHA512: "1a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea",
+			},
+		},
+		modified:          true,
+		getChecksum:       "1a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea",
+		expectedFiles:     []string{"v1/content/test.file1", "v1/content/add.file1"},
+		expectedFilesFlat: []string{"v1/content/test.file2", "v1/content/test.file1", "v1/content/add.file1"},
+		manifestText:      "3 files (2 unique)",
+	},
+	// Adds new filename filename. 3 files, 3 unique.
+	{
+		testData: inventoryEx1,
+		fileData: fileData{
+			stateFilename:    []string{"add.file1"},
+			manifestFilename: "v1/content/add.file1",
+			checksumData: map[checksum.DigestAlgorithm]string{
+				checksum.DigestSHA512: "3a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea",
+			},
+		},
+		modified:          true,
+		getChecksum:       "3a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea",
+		expectedFiles:     []string{"v1/content/add.file1"},
+		expectedFilesFlat: []string{"v1/content/test.file2", "v1/content/test.file1", "v1/content/add.file1"},
+		manifestText:      "3 files (3 unique)",
+	},
+	// Tries to add an identical file with same checksum and name.
+	// 2 files 2 unique.
+	{
+		testData: inventoryEx1,
+		fileData: fileData{
+			stateFilename:    []string{"test.file1"},
+			manifestFilename: "v1/content/test.file1",
+			checksumData: map[checksum.DigestAlgorithm]string{
+				checksum.DigestSHA512: "1a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea",
+			},
+		},
+		modified:          false,
+		getChecksum:       "1a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea",
+		expectedFiles:     []string{"v1/content/test.file1"},
+		expectedFilesFlat: []string{"v1/content/test.file2", "v1/content/test.file1"},
+		manifestText:      "2 files (2 unique)",
+	},
+}
+
+func addFileTest(t *testing.T, test inventoryTest) {
+	ctx := context.TODO()
+	zerologger := zerolog.New(os.Stderr).With().Str("timestamp", time.Now().String()).Logger()
+	var zlogger zLogger.ZLogger = &zerologger
+	var logger = ocfllogger.NewOCFLLogger(ctx, zlogger, nil, version.Default, nil)
+
+	// Initial state.
+	testState := &stateBase{
+		State: map[string][]string{
+			"1a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": []string{"test.file1"},
+			"2a873f7ee602d253faa48a3fb64dde4202194611264f5f33541daaec4400a808c2100b90cda575c1f1a8b0465fa1f8d8c8c4336decd6845d26fbb904060937ea": []string{"test.file2"},
+		},
+	}
+
+	testVersion := &versionBase{
+		Created: inventory.NewOCFLTime(time.Now()),
+		Message: inventory.NewOCFLString(""),
+		State:   testState,
+	}
+
+	testVersions := &versionsBase{
+		// It is unclear why it isn't possible to load the JSON version
+		// into memory so we do it manually.
+		versions:    map[int]inventory.Version{0: testVersion},
+		versionInts: map[string]int{"v1": 0},
+	}
+
+	testInventory := InventoryBase{
+		Manifest: &ManifestBase{
+			manifest: map[string][]string{},
+		},
+		Versions: testVersions,
+		Fixity: &FixityBase{
+			fixity: map[checksum.DigestAlgorithm]map[string][]string{},
+		},
+	}
+
+	err := json.Unmarshal([]byte(test.testData), &testInventory)
+	if err != nil {
+		t.Fatal("error unmarshalling JSON from test:", err)
+	}
+
+	testInventory.logger = logger
+	err = testInventory.AddFile(
+		test.fileData.stateFilename,
+		test.fileData.manifestFilename,
+		test.fileData.checksumData,
+	)
+	if err != nil {
+		t.Errorf("error is not nil: %s", err)
+	}
+
+	if testInventory.modified != test.modified {
+		t.Errorf(
+			"modified state incorrectly updated as '%t', expected: '%t'",
+			testInventory.modified,
+			test.modified,
+		)
+	}
+
+	resManifest := testInventory.Manifest
+	if fmt.Sprintf("%s", resManifest) != test.manifestText {
+		t.Errorf(
+			"didn't receive the correct manifest text: '%s' expectedd '%s'",
+			resManifest,
+			test.manifestText,
+		)
+	}
+
+	files, err := resManifest.GetFiles(test.getChecksum)
+	if err != nil {
+		t.Errorf("retrieving from manifest should be nil: %s", err)
+	}
+
+	if !reflect.DeepEqual(files, test.expectedFiles) {
+		t.Errorf(
+			"manifest is incorrect for checksum, retrieved '%s', expected '%s'",
+			files,
+			test.expectedFiles,
+		)
+	}
+
+	fileList := resManifest.GetFilesFlat()
+	for file := range fileList {
+		if !slices.Contains(test.expectedFilesFlat, strings.TrimSpace(string(file))) {
+			log.Println(file)
+			t.Errorf(
+				"file '%s' not in expected file list, expected '%s'",
+				file,
+				test.expectedFilesFlat,
+			)
+		}
+	}
+}
+
+func TestAddFile(t *testing.T) {
+	for _, test := range inventoryTests {
+		addFileTest(t, test)
+	}
+}

--- a/pkg/ocfl/inventory/inventoryimpl/inventorybase.go
+++ b/pkg/ocfl/inventory/inventoryimpl/inventorybase.go
@@ -467,14 +467,24 @@ func (i *InventoryBase) CopyFile(dest string, digest string) error {
 	return nil
 }
 
-func (i *InventoryBase) AddFile(stateFilenames []string, manifestFilename string, checksums map[checksum.DigestAlgorithm]string) error {
-	i.logger.Debug().Msgf("[%s] adding '%s' -> '%s'", i.GetID(), stateFilenames, manifestFilename)
+func retrieveDigestForFile(
+	i *InventoryBase,
+	checksums map[checksum.DigestAlgorithm]string,
+) (string, error) {
 	digest, ok := checksums[i.GetDigestAlgorithm()]
 	if !ok {
-		return errors.Errorf("no digest for '%s' in checksums", i.GetDigestAlgorithm())
+		return "", errors.Errorf("no digest for '%s' in checksums", i.GetDigestAlgorithm())
 	}
 	digest = strings.ToLower(digest) // paranoia
+	return digest, nil
+}
 
+func addToFixityManifest(
+	i *InventoryBase,
+	digest string,
+	manifestFilename string,
+	checksums map[checksum.DigestAlgorithm]string,
+) (bool, error) {
 	fixitydigests := map[checksum.DigestAlgorithm]string{}
 	for alg, cs := range checksums {
 		if alg == i.GetDigestAlgorithm() {
@@ -484,55 +494,127 @@ func (i *InventoryBase) AddFile(stateFilenames []string, manifestFilename string
 	}
 	modified, err := i.Fixity.AddFile(manifestFilename, fixitydigests)
 	if err != nil {
-		return errors.Wrapf(err, "cannot add fixity '%s' to '%s'", digest, manifestFilename)
+		return false, errors.Wrapf(err, "cannot add fixity '%s' to '%s'", digest, manifestFilename)
+	}
+	return modified, err
+}
+
+func addToManifest(
+	i *InventoryBase,
+	digest string,
+	manifestFilename string,
+) (bool, error) {
+	modified, err := i.Manifest.AddFile(manifestFilename, digest)
+	if err != nil {
+		return false, errors.Wrapf(err, "cannot add manifest '%s' to '%s'", digest, manifestFilename)
+	}
+	return modified, nil
+}
+
+func checkDuplicate(
+	i *InventoryBase,
+	virtualFilename string,
+	digest string,
+	stateFilenames []string,
+) (bool, error) {
+	dup, err := i.AlreadyExists(virtualFilename, digest)
+	if err != nil {
+		return false, errors.Wrapf(err, "cannot add for duplicate of '%s' [%s]", stateFilenames, digest)
+	}
+	if dup {
+		i.logger.Debug().Msgf("'%s' is a duplicate", stateFilenames)
+	}
+	return dup, nil
+}
+
+func addVirtualFile(
+	i *InventoryBase,
+	virtualFilename string,
+	digest string,
+) (bool, error) {
+	modified, err := i.Versions.AddFile(virtualFilename, digest)
+	if err != nil {
+		return modified, errors.Wrapf(err, "cannot add state '%s' to '%s'", digest, virtualFilename)
+	}
+	return modified, nil
+}
+
+func updateIfUpdate(
+	i *InventoryBase,
+	virtualFilename string,
+	digest string,
+	stateFilenames []string,
+) (bool, error) {
+	upd, err := i.IsUpdate(virtualFilename, digest)
+	if err != nil {
+		return false, errors.Wrapf(err, "cannot check for update of '%s' [%s]", stateFilenames, digest)
+	}
+	if upd {
+		i.logger.Debug().Msgf("'%s' is an update - removing old version", stateFilenames)
+		if err := i.DeleteFile(virtualFilename); err != nil {
+			return false, errors.Wrapf(err, "cannot delete old version of '%s' [%s]", stateFilenames, digest)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func addIfNotDuplicate(
+	i *InventoryBase,
+	virtualFilename string,
+	digest string,
+	stateFilenames []string,
+) (bool, error) {
+	modified, err := i.Versions.AddFile(virtualFilename, digest)
+	if err != nil {
+		return false, errors.Wrapf(err, "cannot add version of '%s' [%s]", stateFilenames, digest)
+	}
+	return modified, nil
+}
+
+// AddFile checks whether a file exists in the 'virtual' inventory or
+// can be added and modifies the inventory data accordingly.
+func (i *InventoryBase) AddFile(stateFilenames []string, manifestFilename string, checksums map[checksum.DigestAlgorithm]string) error {
+	i.logger.Debug().Msgf("[%s] adding '%s' -> '%s'", i.GetID(), stateFilenames, manifestFilename)
+	digest, err := retrieveDigestForFile(i, checksums)
+	if err != nil {
+		return err
+	}
+	modified, err := addToFixityManifest(i, digest, manifestFilename, checksums)
+	if err != nil {
+		return err
 	}
 	i.modified = i.modified || modified
-
-	if manifestFilename != "" {
-		modified, err := i.Manifest.AddFile(manifestFilename, digest)
+	if manifestFilename != "" { // if manifest is "" do we want to return an error?
+		modified, err = addToManifest(i, digest, manifestFilename)
 		if err != nil {
-			return errors.Wrapf(err, "cannot add manifest '%s' to '%s'", digest, manifestFilename)
+			return err
 		}
 		i.modified = i.modified || modified
 	}
-
 	for _, virtualFilename := range stateFilenames {
-		dup, err := i.AlreadyExists(virtualFilename, digest)
+		dup, err := checkDuplicate(i, virtualFilename, digest, stateFilenames)
 		if err != nil {
-			return errors.Wrapf(err, "cannot add for duplicate of '%s' [%s]", stateFilenames, digest)
+			return err
 		}
-		if dup {
-			i.logger.Debug().Msgf("'%s' is a duplicate", stateFilenames)
-			// return nil
-		}
-
-		modfied, err := i.Versions.AddFile(virtualFilename, digest)
+		modified, err = addVirtualFile(i, virtualFilename, digest)
 		if err != nil {
-			return errors.Wrapf(err, "cannot add state '%s' to '%s'", digest, virtualFilename)
+			return err
 		}
-		i.modified = i.modified || modfied
-
-		upd, err := i.IsUpdate(virtualFilename, digest)
+		i.modified = i.modified || modified
+		modified, err = updateIfUpdate(i, virtualFilename, digest, stateFilenames)
 		if err != nil {
-			return errors.Wrapf(err, "cannot check for update of '%s' [%s]", stateFilenames, digest)
+			return err
 		}
-		if upd {
-			i.logger.Debug().Msgf("'%s' is an update - removing old version", stateFilenames)
-			if err := i.DeleteFile(virtualFilename); err != nil {
-				return errors.Wrapf(err, "cannot delete old version of '%s' [%s]", stateFilenames, digest)
-			}
-			i.modified = true
-		}
-
+		i.modified = i.modified || modified
 		if !dup {
-			modified, err := i.Versions.AddFile(virtualFilename, digest)
+			modified, err = addIfNotDuplicate(i, virtualFilename, digest, stateFilenames)
 			if err != nil {
-				return errors.Wrapf(err, "cannot add version of '%s' [%s]", stateFilenames, digest)
+				return err
 			}
 			i.modified = i.modified || modified
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Adds tests for the AddFile function within the inventory implementation. 

## Coverage

```
# Before
go test -coverprofile= ./...
	github.com/ocfl-archive/gocfl/v3/pkg/ocfl/inventory/inventoryimpl		coverage: 0.0% of statements

# After
$ go test -coverprofile= ./...
ok  	github.com/ocfl-archive/gocfl/v3/pkg/ocfl/inventory/inventoryimpl	0.009s	coverage: 15.2% of statements
```